### PR TITLE
refactored support and message + added dto's

### DIFF
--- a/api/prisma/migrations/20250802115000_refactor_support_and_message/migration.sql
+++ b/api/prisma/migrations/20250802115000_refactor_support_and_message/migration.sql
@@ -1,0 +1,60 @@
+/*
+  Warnings:
+
+  - Added the required column `body` to the `supports` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "SupportPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "SupportCategory" AS ENUM ('TECHNICAL', 'BILLING', 'RESERVATION', 'GENERAL', 'COMPLAINT', 'FEATURE_REQUEST');
+
+-- AlterTable
+ALTER TABLE "supports" ADD COLUMN     "body" TEXT NOT NULL,
+ADD COLUMN     "category" "SupportCategory" NOT NULL DEFAULT 'GENERAL',
+ADD COLUMN     "priority" "SupportPriority" NOT NULL DEFAULT 'MEDIUM';
+
+-- CreateTable
+CREATE TABLE "support_attachments" (
+    "id" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "original_name" TEXT NOT NULL,
+    "mime_type" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "url" TEXT NOT NULL,
+    "supportId" TEXT NOT NULL,
+    "uploaded_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "support_attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "message_attachments" (
+    "id" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "original_name" TEXT NOT NULL,
+    "mime_type" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "url" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "uploaded_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "message_attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "support_attachments" ADD CONSTRAINT "support_attachments_supportId_fkey" FOREIGN KEY ("supportId") REFERENCES "supports"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "support_attachments" ADD CONSTRAINT "support_attachments_uploaded_by_id_fkey" FOREIGN KEY ("uploaded_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "message_attachments" ADD CONSTRAINT "message_attachments_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "messages"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "message_attachments" ADD CONSTRAINT "message_attachments_uploaded_by_id_fkey" FOREIGN KEY ("uploaded_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -62,6 +62,22 @@ enum SupportStatus {
   CLOSED
 }
 
+enum SupportPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum SupportCategory {
+  TECHNICAL
+  BILLING
+  RESERVATION
+  GENERAL
+  COMPLAINT
+  FEATURE_REQUEST
+}
+
 model User {
   id                      String    @id @default(uuid())
   name                    String
@@ -92,6 +108,8 @@ model User {
   comments  Comment[]
   favorites Favorite[]
   images    Image[]    @relation("UserImages")
+  uploadedAttachments SupportAttachment[] @relation("UploadedAttachments")
+  messageAttachments MessageAttachment[] @relation("MessageAttachments")
 
   @@map("users")
 }
@@ -230,7 +248,10 @@ model Reservation {
 model Support {
   id        String        @id @default(uuid())
   subject   String
+  body      String
   status    SupportStatus @default(OPEN)
+  priority  SupportPriority @default(MEDIUM)
+  category  SupportCategory @default(GENERAL)
   createdAt DateTime      @default(now()) @map("created_at")
   updatedAt DateTime      @updatedAt @map("updated_at")
   closedAt  DateTime?     @map("closed_at")
@@ -242,8 +263,26 @@ model Support {
   supportRepId String?
 
   messages Message[]
+  attachments SupportAttachment[]
 
   @@map("supports")
+}
+
+model SupportAttachment {
+  id          String    @id @default(uuid())
+  filename    String
+  originalName String   @map("original_name")
+  mimeType    String    @map("mime_type")
+  size        Int       // File size in bytes
+  url         String    // Storage URL or path
+  support     Support   @relation(fields: [supportId], references: [id])
+  supportId   String
+  uploadedBy  User      @relation("UploadedAttachments", fields: [uploadedById], references: [id])
+  uploadedById String   @map("uploaded_by_id")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  deletedAt   DateTime? @map("deleted_at")
+
+  @@map("support_attachments")
 }
 
 model Message {
@@ -259,7 +298,26 @@ model Message {
   readAt     DateTime?
   deletedAt  DateTime? @map("deleted_at")
 
+  attachments MessageAttachment[]
+
   @@map("messages")
+}
+
+model MessageAttachment {
+  id          String    @id @default(uuid())
+  filename    String
+  originalName String   @map("original_name")
+  mimeType    String    @map("mime_type")
+  size        Int       // File size in bytes
+  url         String    // Storage URL or path
+  message     Message   @relation(fields: [messageId], references: [id])
+  messageId   String
+  uploadedBy  User      @relation("MessageAttachments", fields: [uploadedById], references: [id])
+  uploadedById String   @map("uploaded_by_id")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  deletedAt   DateTime? @map("deleted_at")
+
+  @@map("message_attachments")
 }
 
 model EmailLog {

--- a/api/src/dto/message/index.ts
+++ b/api/src/dto/message/index.ts
@@ -1,0 +1,3 @@
+export * from "./message.dto";
+export * from "./support-message.dto";
+export * from "./message-attachment.dto";

--- a/api/src/dto/message/message-attachment.dto.ts
+++ b/api/src/dto/message/message-attachment.dto.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const createMessageAttachmentSchema = z.object({
+  messageId: z.string().uuid("Invalid message ID"),
+});
+
+export type CreateMessageAttachmentSchemaType = z.infer<
+  typeof createMessageAttachmentSchema
+>;
+
+// for file upload validation (to be used with multer)
+export const messageAttachmentValidation = {
+  allowedMimeTypes: [
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "application/pdf",
+    "text/plain",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ],
+  maxFileSize: 10 * 1024 * 1024, // 10MB
+  maxFiles: 5,
+};

--- a/api/src/dto/message/message.dto.ts
+++ b/api/src/dto/message/message.dto.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z
+    .string()
+    .min(1, "Message content is required")
+    .max(2000, "Message must be less than 2000 characters"),
+  receiverId: z.string().uuid("Invalid receiver ID"),
+});
+
+export type CreateMessageSchemaType = z.infer<typeof createMessageSchema>;

--- a/api/src/dto/message/support-message.dto.ts
+++ b/api/src/dto/message/support-message.dto.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const createSupportMessageSchema = z.object({
+  content: z
+    .string()
+    .min(1, "Message content is required")
+    .max(2000, "Message must be less than 2000 characters"),
+  supportId: z.string().uuid("Invalid support ID"),
+});
+
+export type CreateSupportMessageSchemaType = z.infer<
+  typeof createSupportMessageSchema
+>;

--- a/api/src/dto/support/assign-support.dto.ts
+++ b/api/src/dto/support/assign-support.dto.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const assignSupportSchema = z.object({
+  supportRepId: z.string().uuid("Invalid support representative ID"),
+});
+
+export type AssignSupportSchemaType = z.infer<typeof assignSupportSchema>;

--- a/api/src/dto/support/close-support.dto.ts
+++ b/api/src/dto/support/close-support.dto.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const closeSupportSchema = z.object({
+  closureMessage: z
+    .string()
+    .max(1000, "Closure message must be less than 1000 characters")
+    .optional(), // this will be added as a message, not stored in Support table
+});
+
+export type CloseSupportSchemaType = z.infer<typeof closeSupportSchema>;

--- a/api/src/dto/support/create-support.dto.ts
+++ b/api/src/dto/support/create-support.dto.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { SupportPriorityEnum, SupportCategoryEnum } from "./enums";
+
+export const createSupportSchema = z.object({
+  subject: z
+    .string()
+    .min(1, "Subject is required")
+    .max(200, "Subject must be less than 200 characters"),
+  body: z
+    .string()
+    .min(1, "Body is required")
+    .max(5000, "Body must be less than 5000 characters"),
+  priority: SupportPriorityEnum.optional().default("MEDIUM"),
+  category: SupportCategoryEnum.optional().default("GENERAL"),
+});
+
+export type CreateSupportSchemaType = z.infer<typeof createSupportSchema>;

--- a/api/src/dto/support/enums.ts
+++ b/api/src/dto/support/enums.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+// seperated enums for reusability
+export const SupportStatusEnum = z.enum([
+  "OPEN",
+  "IN_PROGRESS",
+  "RESOLVED",
+  "CLOSED",
+]);
+export const SupportPriorityEnum = z.enum(["LOW", "MEDIUM", "HIGH", "URGENT"]);
+export const SupportCategoryEnum = z.enum([
+  "TECHNICAL",
+  "BILLING",
+  "RESERVATION",
+  "GENERAL",
+  "COMPLAINT",
+  "FEATURE_REQUEST",
+]);
+
+export type SupportStatus = z.infer<typeof SupportStatusEnum>;
+export type SupportPriority = z.infer<typeof SupportPriorityEnum>;
+export type SupportCategory = z.infer<typeof SupportCategoryEnum>;

--- a/api/src/dto/support/index.ts
+++ b/api/src/dto/support/index.ts
@@ -1,0 +1,7 @@
+export * from "./enums";
+export * from "./create-support.dto";
+export * from "./update-support.dto";
+export * from "./get-support-query.dto";
+export * from "./assign-support.dto";
+export * from "./close-support.dto";
+export * from "./upload-attachment.dto";

--- a/api/src/dto/support/update-support.dto.ts
+++ b/api/src/dto/support/update-support.dto.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import {
+  SupportStatusEnum,
+  SupportPriorityEnum,
+  SupportCategoryEnum,
+} from "./enums";
+
+// all fields are optional for partial updates
+export const updateSupportSchema = z.object({
+  subject: z
+    .string()
+    .min(1, "Subject is required")
+    .max(200, "Subject must be less than 200 characters")
+    .optional(),
+  body: z
+    .string()
+    .min(1, "Body is required")
+    .max(5000, "Body must be less than 5000 characters")
+    .optional(),
+  status: SupportStatusEnum.optional(),
+  priority: SupportPriorityEnum.optional(),
+  category: SupportCategoryEnum.optional(),
+  supportRepId: z.string().uuid("Invalid support representative ID").optional(),
+});
+
+export type UpdateSupportSchemaType = z.infer<typeof updateSupportSchema>;

--- a/api/src/dto/support/upload-attachment.dto.ts
+++ b/api/src/dto/support/upload-attachment.dto.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const uploadAttachmentSchema = z.object({
+  supportId: z.string().uuid("Invalid support ID"),
+});
+
+export type UploadAttachmentSchemaType = z.infer<typeof uploadAttachmentSchema>;
+
+// for file upload validation (to be used with multer)
+export const attachmentValidation = {
+  allowedMimeTypes: [
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "application/pdf",
+    "text/plain",
+    "application/msword", // .doc
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+    "application/vnd.ms-excel", // .xls
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+  ],
+  maxFileSize: 10 * 1024 * 1024, // 10MB
+  maxFiles: 5,
+};


### PR DESCRIPTION
# Support ve Message Modülleri Refactor

### Destek Sistemi Mantığı
Chat supporttan çözülemeyen sorunlara detaylı destek için otomatik olarak bilet oluşturulup ayrı bir destek sayfası açılır.

## Veritabanı Şeması (Prisma) - Genişletme

### Yeni Enum'lar:
➜ `SupportPriority`: LOW, MEDIUM, HIGH, URGENT (destek öncelik seviyeleri)
➜ `SupportCategory`: TECHNICAL, BILLING, RESERVATION, GENERAL, COMPLAINT, FEATURE_REQUEST (destek kategorileri)

### Support Schema:
➜ `body` eklendi - destek talebinin detaylı açıklaması
➜ `priority` eklendi - talebin aciliyet seviyesi
➜ `category` eklendi - talep kategorisi (teknik, faturalandırma, vb.)

### Yeni :
➜ `SupportAttachment` - destek biletlerine dosya ekleri
➜ `MessageAttachment` - mesajlara dosya ekleri

### İlişkiler:
➜ User ↔ Support (müşteri talepleri ve temsilci atamaları)
➜ Support ↔ SupportAttachment (destek dosyaları)
➜ Message ↔ MessageAttachment (mesaj dosyaları)
➜ User ↔ MessageAttachment (kim yükledi)

### DTO'lar
**/src/dto/support/** klasörü :

➜ `enums.ts` - tüm destek enum'ları merkezi yönetim
➜ `create-support.dto.ts` - yeni destek talebi oluşturma
➜ `update-support.dto.ts` - destek talebi güncelleme
➜ `assign-support.dto.ts` - destek temsilcisi atama
➜ `close-support.dto.ts` - destek talebi kapatma (mesaj sistemi ile)
➜ `upload-attachment.dto.ts` - destek dosya ekleri

**/src/dto/message/** klasörü :

➜ `message.dto.ts` - genel mesajlaşma
➜ `support-message.dto.ts` - destek sohbet mesajları
➜ `message-attachment.dto.ts` - mesaj dosya ekleri
